### PR TITLE
Fix keyword arguments in callbacks for Ruby 3.0

### DIFF
--- a/lib/mongo_mapper/plugins/embedded_callbacks.rb
+++ b/lib/mongo_mapper/plugins/embedded_callbacks.rb
@@ -48,9 +48,9 @@ module MongoMapper
                 class << self
                   alias_method :__original_#{callback}, :#{callback}
 
-                  def #{callback}(*args, &block)
+                  def #{callback}(*args, **options, &block)
                     embedded_callbacks_on if @embedded_callbacks_status.nil?
-                    __original_#{callback}(*args, &block)
+                    __original_#{callback}(*args, **options, &block)
                   end
                 end
               CALLBACK


### PR DESCRIPTION
Options for callbacks like `:if` are not passed to ActiveModel's original methods.