### PR TITLE
rails 7 0 jruby 9 2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - jruby
+          - jruby-9.2
           - 2.4.10
           - 2.5.8
           - 2.6.6


### PR DESCRIPTION
- Add Rails 7.0 to matrix test
- Fix NoMethodError ActiveSupport::Callbacks::Callback#raw_filter in Rails 7.0
- Update CHANGELOG.md
- Use jruby-9.2 explicitly
