### PR TITLE
Add shard keys to upsert query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * PR-687 Masato Ikeda <masato.ikeda@gmail.com> Support Rails 7.0
 * PR-688 Masato Ikeda <masato.ikeda@gmail.com> Delegate hash method to proxy target
+* PR-689 Masato Ikeda <masato.ikeda@gmail.com> Add shard keys to upsert query filter
 
 ## 0.15.4 - 2021-06-18
 ### Enhancements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements:
 
 * PR-687 Masato Ikeda <masato.ikeda@gmail.com> Support Rails 7.0
+* PR-688 Masato Ikeda <masato.ikeda@gmail.com> Delegate hash method to proxy target
 
 ## 0.15.4 - 2021-06-18
 ### Enhancements:

--- a/lib/mongo_mapper.rb
+++ b/lib/mongo_mapper.rb
@@ -60,6 +60,7 @@ module MongoMapper
     autoload :Safe,               'mongo_mapper/plugins/safe'
     autoload :Sci,                'mongo_mapper/plugins/sci'
     autoload :Scopes,             'mongo_mapper/plugins/scopes'
+    autoload :Shardable,          'mongo_mapper/plugins/shardable'
     autoload :Serialization,      'mongo_mapper/plugins/serialization'
     autoload :Stats,              'mongo_mapper/plugins/stats'
     autoload :StrongParameters,   'mongo_mapper/plugins/strong_parameters'

--- a/lib/mongo_mapper/document.rb
+++ b/lib/mongo_mapper/document.rb
@@ -39,6 +39,7 @@ module MongoMapper
     include Plugins::PartialUpdates
     include Plugins::IdentityMap
     include Plugins::CounterCache
+    include Plugins::Shardable
 
     included do
       extend Plugins

--- a/lib/mongo_mapper/plugins/associations/proxy/proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/proxy/proxy.rb
@@ -38,6 +38,7 @@ module MongoMapper
           :nil?,
           :blank?,
           :present?,
+          :hash,
           # Active support in rails 3 beta 4 can override to_json after this is loaded,
           # at least when run in mongomapper tests. The implementation was changed in master
           # some time after this, so not sure whether this is still a problem.

--- a/lib/mongo_mapper/plugins/querying.rb
+++ b/lib/mongo_mapper/plugins/querying.rb
@@ -148,7 +148,7 @@ module MongoMapper
         when :insert
           collection.insert_one(update, query_options)
         when :save
-          collection.update_one({:_id => _id}, update, query_options.merge(upsert: true))
+          collection.update_one({:_id => _id}.merge(shard_key_filter), update, query_options.merge(upsert: true))
         when :update
           update.stringify_keys!
 

--- a/lib/mongo_mapper/plugins/shardable.rb
+++ b/lib/mongo_mapper/plugins/shardable.rb
@@ -1,0 +1,30 @@
+module MongoMapper
+  module Plugins
+    module Shardable
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :shard_key_fields
+        self.shard_key_fields = []
+      end
+
+      def shard_key_filter
+        filter = {}
+        shard_key_fields.each do |field|
+          filter[field] = if new_record?
+            send(field)
+          else
+            changed_attributes.key?(field) ? changed_attributes[field] : send(field)
+          end
+        end
+        filter
+      end
+
+      module ClassMethods
+        def shard_key(*fields)
+          self.shard_key_fields = fields.map(&:to_s).freeze
+        end
+      end
+    end
+  end
+end

--- a/spec/functional/shardable_spec.rb
+++ b/spec/functional/shardable_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'Shardable' do
+  let(:sharded_model) {
+    Doc do
+      key :first_name, String
+      key :last_name, String
+      shard_key :first_name, :last_name
+    end
+  }
+
+  describe 'shard_key_fields' do
+    it 'returns declared field names' do
+      sharded_model.shard_key_fields.should == ['first_name', 'last_name']
+    end
+  end
+
+  describe 'shard_key_filter' do
+    context 'new record' do
+      let(:document) { sharded_model.new(first_name: 'John', last_name: 'Smith') }
+
+      it 'returns current values' do
+        document.shard_key_filter.should == { 'first_name' => 'John', 'last_name' => 'Smith' }
+      end
+    end
+
+    context 'persisted record' do
+      let(:document) { sharded_model.create!(first_name: 'John', last_name: 'Smith') }
+
+      before do
+        document.first_name = 'William'
+      end
+
+      it 'returns persisted values' do
+        document.shard_key_filter.should == { 'first_name' => 'John', 'last_name' => 'Smith' }
+      end
+    end
+  end
+
+  context 'creating new document' do
+    let(:document) { sharded_model.new(first_name: 'John', last_name: 'Smith') }
+
+    it 'inserts new document' do
+      lambda { document.save! }.should change { sharded_model.count }.by(1)
+
+      persisted = sharded_model.find(document.id)
+      persisted.first_name.should == 'John'
+      persisted.last_name.should == 'Smith'
+    end
+  end
+
+  context 'updating persisted document' do
+    let(:document) { sharded_model.create!(first_name: 'John', last_name: 'Smith') }
+
+    before do
+      document.first_name = 'William'
+    end
+
+    it 'updates persisted document' do
+      lambda { document.save! }.should_not change { sharded_model.count }
+
+      persisted = sharded_model.find(document.id)
+      persisted.first_name.should == 'William'
+      persisted.last_name.should == 'Smith'
+    end
+  end
+end

--- a/spec/unit/associations/proxy_spec.rb
+++ b/spec/unit/associations/proxy_spec.rb
@@ -108,4 +108,17 @@ describe "Proxy" do
       lambda { @proxy.private_foo }.should raise_error(NoMethodError, /private method `private_foo' called/)
     end
   end
+
+  context "hash" do
+    it "should return the same value for the same proxy" do
+      proxy_a = FakeProxy.new(@owner, @association)
+      proxy_b = FakeProxy.new(@owner, @association)
+
+      proxy_a.hash.should == proxy_b.hash
+    end
+
+    it "should return different values for different proxies" do
+      @proxy.hash.should_not == @nil_proxy.hash
+    end
+  end
 end


### PR DESCRIPTION
MongoDB 4.2 requires full shard keys in the filter of upsert query.
https://docs.mongodb.com/v4.2/release-notes/4.2-compatibility/#sharded-collections-and-replace-documents

Without this changeset, `save!`  can cause:
> Failed to target upsert by query :: could not extract exact shard key

Note that this PR doesn't touch MongoMapper::Plugins::Modifiers::ClassMethods#upsert.
It is because it is a class method and doesn't have any information about a document. So we can't determine shard keys.