### PR TITLE
Proxy hash method to target

### DIFF
--- a/lib/mongo_mapper/plugins/associations/proxy/proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/proxy/proxy.rb
@@ -38,6 +38,7 @@ module MongoMapper
           :nil?,
           :blank?,
           :present?,
+          :hash,
           # Active support in rails 3 beta 4 can override to_json after this is loaded,
           # at least when run in mongomapper tests. The implementation was changed in master
           # some time after this, so not sure whether this is still a problem.

--- a/spec/unit/associations/proxy_spec.rb
+++ b/spec/unit/associations/proxy_spec.rb
@@ -108,4 +108,17 @@ describe "Proxy" do
       lambda { @proxy.private_foo }.should raise_error(NoMethodError, /private method `private_foo' called/)
     end
   end
+
+  context "hash" do
+    it "should return the same value for the same proxy" do
+      proxy_a = FakeProxy.new(@owner, @association)
+      proxy_b = FakeProxy.new(@owner, @association)
+
+      proxy_a.hash.should == proxy_b.hash
+    end
+
+    it "should return different values for different proxies" do
+      @proxy.hash.should_not == @nil_proxy.hash
+    end
+  end
 end


### PR DESCRIPTION
The Kernel#hash method had been proxied to the target object through method_missing in MongoMapper <= 0.15.3.
However, the behavior has been changed since f934b125a6d374c99e2e3ea196ac2de17a6ed0f7.

RSpec's change matcher compares hash values. So this change can break specs.
https://github.com/rspec/rspec-expectations/blob/e63ff4765e1cd2798b02ddddad259f1104ef87a5/lib/rspec/matchers/built_in/change.rb#L397
